### PR TITLE
Update stringy version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/support": "~5.2",
         "illuminate/cache": "~5.2",
         "intervention/image": "^2.1",
-        "danielstjules/stringy": "~2.2"
+        "danielstjules/stringy": "~3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0",


### PR DESCRIPTION
Currently none of the "breaking changes" should affect our usage so it makes sense to be on the top major version.