### PR TITLE
Fix SVG text alignment in Firefox

### DIFF
--- a/src/Avatar.php
+++ b/src/Avatar.php
@@ -177,7 +177,7 @@ class Avatar
 
         $svg .= '<text x="'.$center.'" y="'.$center
             .'" font-size="'.$this->fontSize
-            .'" fill="'.$this->foreground.'" alignment-baseline="middle" text-anchor="middle">'
+            .'" fill="'.$this->foreground.'" alignment-baseline="middle" text-anchor="middle" dominant-baseline="central">'
             .$this->getInitial()
             .'</text>';
 

--- a/tests/AvatarPhpTest.php
+++ b/tests/AvatarPhpTest.php
@@ -131,7 +131,7 @@ class AvatarPhpTest extends \PHPUnit\Framework\TestCase
      */
     public function it_can_generate_base64()
     {
-        $expected = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAALUlEQVQImU2MsQ0AAAjCiv+/xk24qJGlhKQoCZMAAqg3HGuL7TM0+n0AWl2fDaErDmjZIJEtAAAAAElFTkSuQmCC';
+        $expected = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAALUlEQVQImU2MsQ0AAAjCiv+/xk24qJGlhKQoCZMAAqg3HGuL7TM0+n0AWl2fDaErDmjZIJEtAAAAAElFTkSuQmCC';
         $avatar = new \Laravolt\Avatar\Avatar();
         $result = (string)$avatar->create('Citra')->setDimension(5, 5)->toBase64();
 
@@ -176,7 +176,7 @@ class AvatarPhpTest extends \PHPUnit\Framework\TestCase
     {
         $expected = '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" width="100" height="100">';
         $expected .= '<circle cx="50" cy="50" r="45" stroke="yellow" stroke-width="10" fill="red" />';
-        $expected .= '<text x="50" y="50" font-size="24" fill="white" alignment-baseline="middle" text-anchor="middle">AB</text>';
+        $expected .= '<text x="50" y="50" font-size="24" fill="white" alignment-baseline="middle" text-anchor="middle" dominant-baseline="central">AB</text>';
         $expected .= '</svg>';
 
         $avatar = new \Laravolt\Avatar\Avatar();
@@ -199,7 +199,7 @@ class AvatarPhpTest extends \PHPUnit\Framework\TestCase
     {
         $expected = '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" width="100" height="100">';
         $expected .= '<rect x="5" y="5" width="90" height="90" stroke="yellow" stroke-width="10" fill="red" />';
-        $expected .= '<text x="50" y="50" font-size="24" fill="white" alignment-baseline="middle" text-anchor="middle">AB</text>';
+        $expected .= '<text x="50" y="50" font-size="24" fill="white" alignment-baseline="middle" text-anchor="middle" dominant-baseline="central">AB</text>';
         $expected .= '</svg>';
 
         $avatar = new \Laravolt\Avatar\Avatar();
@@ -341,7 +341,7 @@ class AvatarPhpTest extends \PHPUnit\Framework\TestCase
      */
     public function it_can_cast_to_string()
     {
-        $expected = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAALUlEQVQImU2MsQ0AAAjCiv+/xk24qJGlhKQoCZMAAqg3HGuL7TM0+n0AWl2fDaErDmjZIJEtAAAAAElFTkSuQmCC';
+        $expected = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAALUlEQVQImU2MsQ0AAAjCiv+/xk24qJGlhKQoCZMAAqg3HGuL7TM0+n0AWl2fDaErDmjZIJEtAAAAAElFTkSuQmCC';
         $avatar = new \Laravolt\Avatar\Avatar();
         $result = $avatar->create('Citra')->setDimension(5, 5)->__toString();
 


### PR DESCRIPTION
Firefox strictly follows the [SVG spec](https://www.w3.org/TR/SVG11/text.html#AlignmentBaselineProperty), which says that **alignment-baseline** property can be applied to `tspan`, `tref`, `altGlyph` and `textPath` elements. So it ignores this property, since it's used in a `text` element.

This commit adds a **dominant-baseline** property to the text element fixing the vertical alignment issues in Firefox. Hopefully fixes https://github.com/laravolt/avatar/issues/55.