### PR TITLE
Fix cache not storing items indefinitely

### DIFF
--- a/src/Avatar.php
+++ b/src/Avatar.php
@@ -185,7 +185,7 @@ class Avatar
 
         $base64 = $this->image->encode('data-url');
 
-        $this->cache->put($key, $base64, 0);
+        $this->cache->put($key, $base64);
 
         return $base64;
     }


### PR DESCRIPTION
Base64 encoded items aren't stored in the cache indefinitely. In Telescope you can see that items are instantly removed from Redis when the item is put in cache, due to the TTL of 0 seconds. This change was introduced in Laravel 5.8.

https://laravel.com/docs/5.8/upgrade#cache

<img width="953" alt="Screenshot 2020-09-24 at 22 30 33" src="https://user-images.githubusercontent.com/1422996/94202544-c2dcb000-feb5-11ea-849b-8eeca80f00ed.png">
