### PR TITLE
Add support to use foreground and background border colors for svgs

### DIFF
--- a/src/Avatar.php
+++ b/src/Avatar.php
@@ -212,7 +212,7 @@ class Avatar
             $svg .= '<rect x="'.$x
                 .'" y="'.$y
                 .'" width="'.$width.'" height="'.$height
-                .'" stroke="'.$this->borderColor
+                .'" stroke="'.$this->getBorderColor()
                 .'" stroke-width="'.$this->borderSize
                 .'" rx="'.$this->borderRadius
                 .'" fill="'.$this->background.'" />';
@@ -220,7 +220,7 @@ class Avatar
             $svg .= '<circle cx="'.$center
                 .'" cy="'.$center
                 .'" r="'.$radius
-                .'" stroke="'.$this->borderColor
+                .'" stroke="'.$this->getBorderColor()
                 .'" stroke-width="'.$this->borderSize
                 .'" fill="'.$this->background.'" />';
         }

--- a/tests/AvatarPhpTest.php
+++ b/tests/AvatarPhpTest.php
@@ -23,7 +23,7 @@ class AvatarPhpTest extends \PHPUnit\Framework\TestCase
         $avatar = new \Laravolt\Avatar\Avatar($config);
 
         $this->assertEquals(2, $avatar->getAttribute('chars'));
-        $this->assertEquals('circle',$avatar->getAttribute('shape'));
+        $this->assertEquals('circle', $avatar->getAttribute('shape'));
         $this->assertEquals(200, $avatar->getAttribute('width'));
         $this->assertEquals(200, $avatar->getAttribute('height'));
         $this->assertEquals(['#000000'], $avatar->getAttribute('availableBackgrounds'));

--- a/tests/AvatarPhpTest.php
+++ b/tests/AvatarPhpTest.php
@@ -311,6 +311,50 @@ class AvatarPhpTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
+    public function it_can_use_the_foreground_color_for_the_svg_border()
+    {
+        $expected = '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">';
+        $expected .= '<circle cx="50" cy="50" r="45" stroke="green" stroke-width="10" fill="red" />';
+        $expected .= '<text x="50" y="50" font-size="24" fill="green" alignment-baseline="middle" text-anchor="middle" dominant-baseline="central">AB</text>';
+        $expected .= '</svg>';
+
+        $avatar = new \Laravolt\Avatar\Avatar(['border' => ['size' => 10, 'color' => 'foreground']]);
+        $svg = $avatar->create('Andi Budiman')
+                      ->setShape('circle')
+                      ->setFontSize(24)
+                      ->setDimension(100, 100)
+                      ->setForeground('green')
+                      ->setBackground('red')
+                      ->toSvg();
+
+        $this->assertEquals($expected, $svg);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_use_the_background_color_for_the_svg_border()
+    {
+        $expected = '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">';
+        $expected .= '<circle cx="50" cy="50" r="45" stroke="red" stroke-width="10" fill="red" />';
+        $expected .= '<text x="50" y="50" font-size="24" fill="green" alignment-baseline="middle" text-anchor="middle" dominant-baseline="central">AB</text>';
+        $expected .= '</svg>';
+
+        $avatar = new \Laravolt\Avatar\Avatar(['border' => ['size' => 10, 'color' => 'background']]);
+        $svg = $avatar->create('Andi Budiman')
+                      ->setShape('circle')
+                      ->setFontSize(24)
+                      ->setDimension(100, 100)
+                      ->setForeground('green')
+                      ->setBackground('red')
+                      ->toSvg();
+
+        $this->assertEquals($expected, $svg);
+    }
+
+    /**
+     * @test
+     */
     public function it_can_generate_gravatar()
     {
         $expected = 'https://www.gravatar.com/avatar/0dcae7d6d76f9a3b14588e9671c45879';


### PR DESCRIPTION
When you use the setting
```php
'border' => [
    'color' => 'foreground',
]
```

And the `toSvg()` method
The border of the svg is not using the *foreground* color, but just the string 'foreground'.

```
<circle cx="25" cy="25" r="24" stroke="foreground" stroke-width="2" fill="#feb2b2"></circle>
```

This PR fixes that by calling the `getBorderColor()` method instead of the `borderColor` property.