### PR TITLE
fix: dont pass null to strlen()

### DIFF
--- a/src/Avatar.php
+++ b/src/Avatar.php
@@ -416,7 +416,7 @@ class Avatar
         $array = array_values($array);
 
         $name = $this->name;
-        if (strlen($name) === 0) {
+        if ($name === null || strlen($name) === 0) {
             $name = chr(rand(65, 90));
         }
 


### PR DESCRIPTION
resolves:
```
Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated {"exception":"[object] (ErrorException(code: 0): Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated at /home/www/app/vendor/laravolt/avatar/src/Avatar.php:419
```