### PR TITLE
Update Gravatar hashing to use sha256

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,12 @@ Avatar::create('Susilo Bambang Yudhoyono')->save('sample.jpg', 100); // quality 
 ### Output as Gravatar
 ```php
 Avatar::create('uyab@example.net')->toGravatar();
-// Output: http://gravatar.com/avatar/0dcae7d6d76f9a3b14588e9671c45879
+// Output: http://gravatar.com/avatar/0c5cbf5a8762d91d930795a6107b2ce5814a6ab26e60c7ec6b75bc81c7dfe3ee
 
 Avatar::create('uyab@example.net')->toGravatar(['d' => 'identicon', 'r' => 'pg', 's' => 100]);
-// Output: http://gravatar.com/avatar/0dcae7d6d76f9a3b14588e9671c45879?d=identicon&r=pg&s=100
+// Output: http://gravatar.com/avatar/0c5cbf5a8762d91d930795a6107b2ce5814a6ab26e60c7ec6b75bc81c7dfe3ee?d=identicon&r=pg&s=100
 ```
-Gravatar parameter reference: https://en.gravatar.com/site/implement/images/
+Gravatar parameter reference: https://docs.gravatar.com/api/avatars/images/
 
 ### Output as SVG
 ```php

--- a/src/Avatar.php
+++ b/src/Avatar.php
@@ -247,7 +247,7 @@ class Avatar
     public function toGravatar(array $param = null): string
     {
         // Hash generation taken from https://docs.gravatar.com/api/avatars/php/
-        $hash = hash('sha256',strtolower(trim($this->name)));
+        $hash = hash('sha256', strtolower(trim($this->name)));
 
         $attributes = [];
         if ($this->width) {

--- a/src/Avatar.php
+++ b/src/Avatar.php
@@ -246,8 +246,8 @@ class Avatar
 
     public function toGravatar(array $param = null): string
     {
-        // Hash generation taken from https://en.gravatar.com/site/implement/images/php/
-        $hash = md5(strtolower(trim($this->name)));
+        // Hash generation taken from https://docs.gravatar.com/api/avatars/php/
+        $hash = hash('sha256',strtolower(trim($this->name)));
 
         $attributes = [];
         if ($this->width) {

--- a/tests/AvatarPhpTest.php
+++ b/tests/AvatarPhpTest.php
@@ -386,7 +386,7 @@ class AvatarPhpTest extends \PHPUnit\Framework\TestCase
      */
     public function it_can_generate_gravatar()
     {
-        $expected = 'https://www.gravatar.com/avatar/0dcae7d6d76f9a3b14588e9671c45879?s=88';
+        $expected = 'https://www.gravatar.com/avatar/0c5cbf5a8762d91d930795a6107b2ce5814a6ab26e60c7ec6b75bc81c7dfe3ee?s=88';
 
         $avatar = new \Laravolt\Avatar\Avatar();
         $url = $avatar
@@ -402,7 +402,7 @@ class AvatarPhpTest extends \PHPUnit\Framework\TestCase
      */
     public function it_can_generate_gravatar_with_size()
     {
-        $expected = 'https://www.gravatar.com/avatar/0dcae7d6d76f9a3b14588e9671c45879?s=100';
+        $expected = 'https://www.gravatar.com/avatar/0c5cbf5a8762d91d930795a6107b2ce5814a6ab26e60c7ec6b75bc81c7dfe3ee?s=100';
 
         $avatar = new \Laravolt\Avatar\Avatar();
         $url = $avatar->create('uyab.exe@gmail.com')
@@ -417,7 +417,7 @@ class AvatarPhpTest extends \PHPUnit\Framework\TestCase
      */
     public function it_can_generate_gravatar_with_default()
     {
-        $expected = 'https://www.gravatar.com/avatar/0dcae7d6d76f9a3b14588e9671c45879?d=identicon&s=100';
+        $expected = 'https://www.gravatar.com/avatar/0c5cbf5a8762d91d930795a6107b2ce5814a6ab26e60c7ec6b75bc81c7dfe3ee?d=identicon&s=100';
 
         $avatar = new \Laravolt\Avatar\Avatar();
         $url = $avatar->create('uyab.exe@gmail.com')
@@ -432,7 +432,7 @@ class AvatarPhpTest extends \PHPUnit\Framework\TestCase
      */
     public function it_can_generate_gravatar_with_default_and_rating()
     {
-        $expected = 'https://www.gravatar.com/avatar/0dcae7d6d76f9a3b14588e9671c45879?d=identicon&r=pg&s=100';
+        $expected = 'https://www.gravatar.com/avatar/0c5cbf5a8762d91d930795a6107b2ce5814a6ab26e60c7ec6b75bc81c7dfe3ee?d=identicon&r=pg&s=100';
 
         $avatar = new \Laravolt\Avatar\Avatar();
         $url = $avatar->create('uyab.exe@gmail.com')
@@ -447,7 +447,7 @@ class AvatarPhpTest extends \PHPUnit\Framework\TestCase
      */
     public function it_can_generate_gravatar_with_size_overriden()
     {
-        $expected = 'https://www.gravatar.com/avatar/0dcae7d6d76f9a3b14588e9671c45879?s=300';
+        $expected = 'https://www.gravatar.com/avatar/0c5cbf5a8762d91d930795a6107b2ce5814a6ab26e60c7ec6b75bc81c7dfe3ee?s=300';
 
         $avatar = new \Laravolt\Avatar\Avatar();
         $url = $avatar->create('uyab.exe@gmail.com')


### PR DESCRIPTION
Gravatar added support for both MD5 and SHA256, this PR migrates Gravatar's usage to the new sha256 hashing algorithm.

Source: https://docs.gravatar.com/api/avatars/php