### PR TITLE
Fix `parameter.implicitlyNullable` for PHP 8.4 compatibility.

### DIFF
--- a/src/Avatar.php
+++ b/src/Avatar.php
@@ -84,7 +84,7 @@ class Avatar
      * @param array $config
      * @param Repository $cache
      */
-    public function __construct(array $config = [], Repository $cache = null)
+    public function __construct(array $config = [], ?Repository $cache = null)
     {
         $this->cache = $cache ?? new ArrayStore();
         $this->driver = $config['driver'] ?? 'gd';
@@ -251,7 +251,7 @@ class Avatar
         return $svg;
     }
 
-    public function toGravatar(array $param = null): string
+    public function toGravatar(?array $param = null): string
     {
         // Hash generation taken from https://docs.gravatar.com/api/avatars/php/
         $hash = hash('sha256', strtolower(trim($this->name)));


### PR DESCRIPTION
As the title suggests improve type annotations where they already exist to prevent deprecation warnings for newer versions of PHP. I assume no back porting option to 5.x?