### PR TITLE
Migrate to Intervention Image v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": ">=8.2",
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/cache": "^10.0|^11.0|^12.0|^13.0",
-        "intervention/image": "^3.4"
+        "intervention/image": "^4.0"
     },
     "suggest": {
         "ext-gd": "Needed to support image manipulation",

--- a/src/Avatar.php
+++ b/src/Avatar.php
@@ -4,8 +4,9 @@ namespace Laravolt\Avatar;
 
 use Illuminate\Cache\ArrayStore;
 use Illuminate\Contracts\Cache\Repository;
-use Intervention\Image\Drivers\Gd\Driver;
+use Intervention\Image\Drivers\Gd\Driver as GdDriver;
 use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
+use Intervention\Image\Format;
 use Intervention\Image\Geometry\Factories\CircleFactory;
 use Intervention\Image\Geometry\Factories\RectangleFactory;
 use Intervention\Image\ImageManager;
@@ -198,7 +199,7 @@ class Avatar
             // Skip cache if it's disabled
             $this->buildAvatar();
 
-            return $this->image->toPng()->toDataUri();
+            return $this->image->encodeUsingFormat(Format::PNG)->toDataUri();
         }
 
         $key = $this->cacheKeyPrefix.$this->cacheKey();
@@ -210,7 +211,7 @@ class Avatar
 
         // Generate the avatar
         $this->buildAvatar();
-        $base64 = $this->image->toPng()->toDataUri();
+        $base64 = $this->image->encodeUsingFormat(Format::PNG)->toDataUri();
 
         // Store in cache based on configured duration
         if ($this->cacheDuration === null) {
@@ -352,9 +353,8 @@ class Avatar
         $x = $this->width / 2;
         $y = $this->height / 2;
 
-        $driver = $this->driver === 'gd' ? new Driver : new ImagickDriver;
-        $manager = new ImageManager($driver);
-        $this->image = $manager->create($this->width, $this->height);
+        $driver = $this->driver === 'gd' ? new GdDriver : new ImagickDriver;
+        $this->image = ImageManager::usingDriver($driver)->createImage($this->width, $this->height);
 
         $this->createShape();
 
@@ -367,11 +367,10 @@ class Avatar
             (int) $x,
             (int) $y,
             function (FontFactory $font) {
-                $font->file($this->font);
+                $font->filepath($this->font);
                 $font->size($this->fontSize);
                 $font->color($this->foreground);
-                $font->align('center');
-                $font->valign('middle');
+                $font->align('center', 'middle');
             }
         );
 
@@ -394,15 +393,12 @@ class Avatar
         $x = (int) ($this->width / 2);
         $y = (int) ($this->height / 2);
 
-        $this->image->drawCircle(
-            $x,
-            $y,
-            function (CircleFactory $circle) use ($circleDiameter) {
-                $circle->diameter($circleDiameter);
-                $circle->border($this->getBorderColor(), $this->borderSize);
-                $circle->background($this->background);
-            }
-        );
+        $this->image->drawCircle(function (CircleFactory $circle) use ($circleDiameter, $x, $y) {
+            $circle->diameter($circleDiameter);
+            $circle->at($x, $y);
+            $circle->border($this->getBorderColor(), $this->borderSize);
+            $circle->background($this->background);
+        });
     }
 
     protected function createSquareShape(): void
@@ -412,15 +408,12 @@ class Avatar
         $width = $this->width - $edge;
         $height = $this->height - $edge;
 
-        $this->image->drawRectangle(
-            $x,
-            $y,
-            function (RectangleFactory $draw) use ($width, $height) {
-                $draw->size($width, $height);
-                $draw->background($this->background);
-                $draw->border($this->getBorderColor(), $this->borderSize);
-            }
-        );
+        $this->image->drawRectangle(function (RectangleFactory $rectangle) use ($x, $y, $width, $height) {
+            $rectangle->at($x, $y);
+            $rectangle->size($width, $height);
+            $rectangle->background($this->background);
+            $rectangle->border($this->getBorderColor(), $this->borderSize);
+        });
     }
 
     protected function cacheKey(): string

--- a/src/Concerns/ImageExport.php
+++ b/src/Concerns/ImageExport.php
@@ -5,7 +5,14 @@ declare(strict_types=1);
 namespace Laravolt\Avatar\Concerns;
 
 use Illuminate\Support\Facades\Storage;
+use Intervention\Image\Color;
+use Intervention\Image\Encoders\JpegEncoder;
+use Intervention\Image\Encoders\PngEncoder;
+use Intervention\Image\Encoders\WebpEncoder;
+use Intervention\Image\Format;
+use Intervention\Image\ImageManager;
 use Intervention\Image\Interfaces\ImageInterface;
+use Intervention\Image\Typography\FontFactory;
 
 /**
  * Image Export Trait
@@ -42,16 +49,11 @@ trait ImageExport
      */
     protected function exportPNG(string $path, array $options): ImageInterface
     {
-        $quality = $options['quality'] ?? 95;
-        $compression = $options['compression'] ?? 6;
         $interlaced = $options['interlaced'] ?? false;
 
-        // Apply PNG-specific optimizations
-        if ($interlaced) {
-            $this->image->interlace();
-        }
+        $encoder = new PngEncoder($interlaced);
 
-        return $this->image->toPng($quality)->save($path);
+        return $this->image->encode($encoder)->save($path);
     }
 
     /**
@@ -62,12 +64,9 @@ trait ImageExport
         $quality = $options['quality'] ?? 90;
         $progressive = $options['progressive'] ?? true;
 
-        // Apply JPEG-specific optimizations
-        if ($progressive) {
-            $this->image->interlace();
-        }
+        $encoder = new JpegEncoder($quality, $progressive);
 
-        return $this->image->toJpeg($quality)->save($path);
+        return $this->image->encode($encoder)->save($path);
     }
 
     /**
@@ -81,7 +80,9 @@ trait ImageExport
         // Apply WebP-specific optimizations
         $webpQuality = $lossless ? 100 : $quality;
 
-        return $this->image->toWebp($webpQuality)->save($path);
+        $encoder = new WebpEncoder($webpQuality);
+
+        return $this->image->encode($encoder)->save($path);
     }
 
     /**
@@ -174,18 +175,18 @@ trait ImageExport
         // Calculate position coordinates
         [$x, $y] = $this->calculateWatermarkPosition($position, $text, $fontSize);
 
+        $colorObject = Color::parse($color)->withTransparency($opacity);
+
         // Apply watermark
         $this->image->text(
             $text,
             $x,
             $y,
-            function ($font) use ($fontSize, $color, $opacity) {
+            function (FontFactory $font) use ($fontSize, $colorObject) {
                 $font->file($this->font);
                 $font->size($fontSize);
-                $font->color($color);
-                $font->alpha($opacity);
-                $font->align('left');
-                $font->valign('bottom');
+                $font->color($colorObject);
+                $font->align('left', 'bottom');
             }
         );
     }
@@ -217,8 +218,7 @@ trait ImageExport
 
         // Create sprite canvas
         $driver = $this->driver === 'gd' ? new \Intervention\Image\Drivers\Gd\Driver : new \Intervention\Image\Drivers\Imagick\Driver;
-        $manager = new \Intervention\Image\ImageManager($driver);
-        $sprite = $manager->create($spriteWidth, $spriteHeight);
+        $sprite = ImageManager::usingDriver($driver)->createImage($spriteWidth, $spriteHeight);
 
         // Add each variation to the sprite
         $x = 0;
@@ -228,17 +228,21 @@ trait ImageExport
             $this->buildAvatar();
 
             // Copy to sprite at current x position
-            $sprite->place($this->image, 'top-left', $x, 0);
+            $sprite->insert($this->image, $x, 0, 'top-left');
             $x += $this->width;
         }
 
-        // Export sprite sheet
-        return match (strtolower($format)) {
-            'png' => $sprite->toPng()->save($path),
-            'jpg', 'jpeg' => $sprite->toJpeg()->save($path),
-            'webp' => $sprite->toWebp()->save($path),
+        $outputFormat = match (strtolower($format)) {
+            'png' => Format::PNG,
+            'jpg', 'jpeg' => Format::JPEG,
+            'webp' => Format::WEBP,
             default => throw new \InvalidArgumentException("Unsupported format: {$format}")
         };
+
+        // Export sprite sheet
+        $sprite->encodeUsingFormat($outputFormat)->save($path);
+
+        return $sprite;
     }
 
     /**

--- a/src/Concerns/StorageOptimization.php
+++ b/src/Concerns/StorageOptimization.php
@@ -7,6 +7,7 @@ namespace Laravolt\Avatar\Concerns;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
+use Intervention\Image\Format;
 use Intervention\Image\Image;
 
 /**
@@ -83,9 +84,9 @@ trait StorageOptimization
 
         // Save the optimized image
         match (strtolower($format)) {
-            'png' => $image->toPng(...$options)->save($fullPath),
-            'jpg', 'jpeg' => $image->toJpeg(...$options)->save($fullPath),
-            'webp' => $image->toWebp(...$options)->save($fullPath),
+            'png' => $image->encodeUsingFormat(Format::PNG, ...$options)->save($fullPath),
+            'jpg', 'jpeg' => $image->encodeUsingFormat(Format::JPEG, ...$options)->save($fullPath),
+            'webp' => $image->encodeUsingFormat(Format::WEBP, ...$options)->save($fullPath),
         };
 
         // Update storage metrics


### PR DESCRIPTION
This PR makes the necessary changes to migrate to the just released [Intervention Image Version 4](https://github.com/Intervention/image/releases/tag/4.0.0).

Please note that the new version requires at least PHP 8.3.

I recommend a thorough review and testing. However, I think this is a good start and takes care of most of the work for the update. 

If you have any questions, feel free to reach out to me.

PS: For your reference, here is the [upgrade guide](https://image.intervention.io/v4/getting-started/upgrade)