### PR TITLE
fix: changed alignment from middle to center

### DIFF
--- a/src/Avatar.php
+++ b/src/Avatar.php
@@ -4,6 +4,7 @@ namespace Laravolt\Avatar;
 
 use Illuminate\Cache\ArrayStore;
 use Illuminate\Contracts\Cache\Repository;
+use Intervention\Image\Alignment;
 use Intervention\Image\Drivers\Gd\Driver as GdDriver;
 use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
 use Intervention\Image\Format;
@@ -370,7 +371,7 @@ class Avatar
                 $font->filepath($this->font);
                 $font->size($this->fontSize);
                 $font->color($this->foreground);
-                $font->align('center', 'middle');
+                $font->align(Alignment::CENTER, Alignment::CENTER);
             }
         );
 


### PR DESCRIPTION
This PR addresses an issue with the latest release, `v6.5.0`, where `Avatar::create('John Doe')->toBase64();` throws an `invalid value for alignment` error.

<img width="1918" height="967" alt="image" src="https://github.com/user-attachments/assets/d7bb5a73-da73-4f54-a6f0-c744f268cf81" />

**Result**
<img width="1915" height="958" alt="image" src="https://github.com/user-attachments/assets/86dfd786-8df0-4398-9347-5513973fdd96" />
