### PR TITLE
Fix stale cache key in toBase64() causing duplicate cache entries

### DIFF
--- a/src/Avatar.php
+++ b/src/Avatar.php
@@ -203,6 +203,10 @@ class Avatar
             return $this->image->encodeUsingFormat(Format::PNG)->toDataUri();
         }
 
+        // Ensure $initials is populated before computing the cache key,
+        // otherwise every avatar shares an empty-initials key (#182)
+        $this->buildInitial();
+
         $key = $this->cacheKeyPrefix.$this->cacheKey();
 
         // Check if the image is in the cache

--- a/tests/AvatarPhpTest.php
+++ b/tests/AvatarPhpTest.php
@@ -205,6 +205,28 @@ class AvatarPhpTest extends \PHPUnit\Framework\TestCase
     }
 
     #[Test]
+    public function it_uses_distinct_cache_keys_for_different_names()
+    {
+        $keys = [];
+
+        $cache = Mockery::mock('Illuminate\Contracts\Cache\Repository');
+        $cache->shouldReceive('get')->andReturnUsing(function ($key) use (&$keys) {
+            $keys[] = $key;
+
+            return null;
+        });
+        $cache->shouldReceive('forever');
+        $cache->shouldReceive('put');
+
+        $avatar = new \Laravolt\Avatar\Avatar([], $cache);
+        $avatar->create('Citra')->setDimension(5, 5)->toBase64();
+        $avatar->create('Rama')->setDimension(5, 5)->toBase64();
+
+        $this->assertCount(2, $keys);
+        $this->assertNotEquals($keys[0], $keys[1]);
+    }
+
+    #[Test]
     public function it_can_generate_file()
     {
         $file = __DIR__.'/avatar.png';


### PR DESCRIPTION
Fixes #182

## Problem
`toBase64()` computed the cache key before `buildInitial()` ran, so `$this->initials` (used by `cacheKey()`) was still empty. Every avatar therefore hashed the same empty initials, producing excess/duplicate cache entries (reporter saw ~120 entries for 20 users).

## Fix
Call `$this->buildInitial()` before computing the cache key, exactly as suggested by the reporter in #182.

## Tests
- New regression test `it_uses_distinct_cache_keys_for_different_names` asserting two different names hit the cache with distinct keys.
- Full suite: 107 tests, 241 assertions, all passing.